### PR TITLE
Fix refresh behavior

### DIFF
--- a/app/services/devise/api/tokens_service/create.rb
+++ b/app/services/devise/api/tokens_service/create.rb
@@ -8,7 +8,7 @@ module Devise
         option :previous_refresh_token, type: Types::String | Types::Nil, default: proc { nil }
 
         def call
-          return Failure(:invalid_resource_owner) unless resource_owner.respond_to?(:access_tokens)
+          return Failure(error: :invalid_resource_owner) unless resource_owner.respond_to?(:access_tokens)
 
           devise_api_token = yield create_devise_api_token
 

--- a/app/services/devise/api/tokens_service/refresh.rb
+++ b/app/services/devise/api/tokens_service/refresh.rb
@@ -8,7 +8,7 @@ module Devise
         option :resource_owner, default: proc { devise_api_token.resource_owner }
 
         def call
-          return Failure(:expired_refresh_token) if devise_api_token.refresh_token_expired?
+          return Failure(error: :expired_refresh_token) if devise_api_token.refresh_token_expired?
 
           devise_api_token = yield create_devise_api_token
           Success(devise_api_token)

--- a/lib/devise/api/controllers/helpers.rb
+++ b/lib/devise/api/controllers/helpers.rb
@@ -38,18 +38,11 @@ module Devise
         end
 
         def current_devise_api_token
+          return @current_devise_api_token if @current_devise_api_token
+
           token = find_devise_api_token
-
           devise_api_token_model = Devise.api.config.base_token_model.constantize
-
-          if Devise.api.config.refresh_token.enabled
-            return devise_api_token_model
-                   .where(access_token: token)
-                   .or(devise_api_token_model.where(refresh_token: token))
-                     &.first
-          end
-
-          devise_api_token_model.find_by(access_token: token)
+          @current_devise_api_token = devise_api_token_model.find_by(access_token: token)
         end
 
         def current_devise_api_user

--- a/lib/devise/api/token.rb
+++ b/lib/devise/api/token.rb
@@ -41,7 +41,7 @@ module Devise
       end
 
       def inactive?
-        revoked? && expired?
+        revoked? || expired?
       end
 
       def expired?
@@ -51,7 +51,7 @@ module Devise
       end
 
       def refresh_token_expired?
-        return false unless Devise.api.config.refresh_token.expires_in_infinite.call(resource_owner)
+        return false if Devise.api.config.refresh_token.expires_in_infinite.call(resource_owner)
 
         Time.now.utc > refresh_token_expires_at
       end

--- a/spec/requests/tokens_spec.rb
+++ b/spec/requests/tokens_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe Devise::Api::TokensController, type: :request do
         allow(Devise.api.config.before_refresh).to receive(:call).and_call_original
         allow(Devise.api.config.after_successful_refresh).to receive(:call).and_call_original
 
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, true), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
       end
 
       it 'returns http success' do

--- a/spec/requests/tokens_spec.rb
+++ b/spec/requests/tokens_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe Devise::Api::TokensController, type: :request do
         allow(Devise.api.config.before_refresh).to receive(:call).and_call_original
         allow(Devise.api.config.after_successful_refresh).to receive(:call).and_call_original
 
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, true), as: :json
       end
 
       it 'returns http success' do
@@ -540,8 +540,8 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       end
 
       it 'returns an error response' do
-        expect(parsed_body.error).to eq 'expired_token'
-        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.expired_token')])
+        expect(parsed_body.error).to eq 'invalid_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.invalid_token')])
       end
 
       it 'does not refresh the token' do
@@ -562,8 +562,8 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       end
 
       it 'returns an error response' do
-        expect(parsed_body.error).to eq 'revoked_token'
-        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.revoked_token')])
+        expect(parsed_body.error).to eq 'invalid_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.invalid_token')])
       end
 
       it 'does not refresh the token' do

--- a/spec/supports/helpers/devise_api_token_helper.rb
+++ b/spec/supports/helpers/devise_api_token_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module DeviseApiTokenHelper
-  def authentication_headers_for(resource_owner, token = nil, refreshing = nil)
+  def authentication_headers_for(resource_owner, token = nil, token_type = access_token)
     token = FactoryBot.create(:devise_api_token, resource_owner: resource_owner) if token.blank?
-    bearer = refreshing ? token.refresh_token : token.access_token
+    token_value = token.send(token_type.to_sym)
 
-    { 'Authorization': "Bearer #{bearer}" }
+    { 'Authorization': "Bearer #{token_value)}" }
   end
 end
 

--- a/spec/supports/helpers/devise_api_token_helper.rb
+++ b/spec/supports/helpers/devise_api_token_helper.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 module DeviseApiTokenHelper
-  def authentication_headers_for(resource_owner, token = nil)
+  def authentication_headers_for(resource_owner, token = nil, refreshing = nil)
     token = FactoryBot.create(:devise_api_token, resource_owner: resource_owner) if token.blank?
+    bearer = refreshing ? token.refresh_token : token.access_token
 
-    { 'Authorization': "Bearer #{token.access_token}" }
+    { 'Authorization': "Bearer #{bearer}" }
   end
 end
 

--- a/spec/supports/helpers/devise_api_token_helper.rb
+++ b/spec/supports/helpers/devise_api_token_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module DeviseApiTokenHelper
-  def authentication_headers_for(resource_owner, token = nil, token_type = access_token)
+  def authentication_headers_for(resource_owner, token = nil, token_type = :access_token)
     token = FactoryBot.create(:devise_api_token, resource_owner: resource_owner) if token.blank?
-    token_value = token.send(token_type.to_sym)
+    token_value = token.send(token_type)
 
-    { 'Authorization': "Bearer #{token_value)}" }
+    { 'Authorization': "Bearer #{token_value}" }
   end
 end
 


### PR DESCRIPTION
We've been inspired by [this fork](https://github.com/aragro/devise-api/commit/d09e2cd9a736c5b1b1af65e7f59ba6f06b860380)

- Added missing failure keys 'error'
- Fixed token & refresh token rules for expiration & validity
- Made authenticate_devise_api_token! helper only authenticate for valid access_token