### PR TITLE
Fix undefined variable error in controller helper

### DIFF
--- a/lib/devise/api/controllers/helpers.rb
+++ b/lib/devise/api/controllers/helpers.rb
@@ -58,6 +58,10 @@ module Devise
 
         private
 
+        def resource_class
+          current_devise_api_user&.class
+        end
+
         def extract_devise_api_token_from_params
           params[Devise.api.config.authorization.params_key]
         end

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HomeController < ApplicationController
+  skip_before_action :verify_authenticity_token, raise: false
+  before_action :authenticate_devise_api_token!
+
+  def index
+    render json: { success: true }
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   devise_for :users
+  get :home, to: 'home#index'
 end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication', type: :request do
+  describe 'GET /home' do
+    context 'when the token is valid and on the header' do
+      let(:user) { create(:user) }
+      let(:devise_api_token) { create(:devise_api_token, resource_owner: user) }
+
+      before do
+        get home_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+      end
+
+      it 'returns the correct response' do
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body)).to eql({ 'success' => true })
+      end
+    end
+
+    context 'when the token is valid and on the url param' do
+      let(:user) { create(:user) }
+      let(:devise_api_token) { create(:devise_api_token, resource_owner: user) }
+
+      before do
+        get home_path(access_token: devise_api_token.access_token), as: :json
+      end
+
+      it 'returns the correct response' do
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body)).to eql({ 'success' => true })
+      end
+    end
+
+    context 'when the token is invalid and on the header' do
+      let(:user) { create(:user) }
+      let(:devise_api_token) { build(:devise_api_token, resource_owner: user) }
+
+      before do
+        get home_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+      end
+
+      it 'returns http unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error response' do
+        expect(parsed_body.error).to eq 'invalid_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.invalid_token')])
+      end
+
+      it 'does not return the authenticated resource owner' do
+        expect(parsed_body.id).to be_nil
+        expect(parsed_body.email).to be_nil
+        expect(parsed_body.created_at).to be_nil
+        expect(parsed_body.updated_at).to be_nil
+      end
+    end
+
+    context 'when the token is invalid and on the url param' do
+      before do
+        get home_path(access_token: 'invalid'), as: :json
+      end
+
+      it 'returns http unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error response' do
+        expect(parsed_body.error).to eq 'invalid_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.invalid_token')])
+      end
+
+      it 'does not return the authenticated resource owner' do
+        expect(parsed_body.id).to be_nil
+        expect(parsed_body.email).to be_nil
+        expect(parsed_body.created_at).to be_nil
+        expect(parsed_body.updated_at).to be_nil
+      end
+    end
+
+    context 'when the token is expired' do
+      let(:user) { create(:user) }
+      let(:devise_api_token) { create(:devise_api_token, :access_token_expired, resource_owner: user) }
+
+      before do
+        get home_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+      end
+
+      it 'returns http unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error response' do
+        expect(parsed_body.error).to eq 'expired_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.expired_token')])
+      end
+
+      it 'does not return the authenticated resource owner' do
+        expect(parsed_body.id).to be_nil
+        expect(parsed_body.email).to be_nil
+        expect(parsed_body.created_at).to be_nil
+        expect(parsed_body.updated_at).to be_nil
+      end
+    end
+
+    context 'when the token is revoked' do
+      let(:user) { create(:user) }
+      let(:devise_api_token) { create(:devise_api_token, :revoked, resource_owner: user) }
+
+      before do
+        get home_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+      end
+
+      it 'returns http unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error response' do
+        expect(parsed_body.error).to eq 'revoked_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.revoked_token')])
+      end
+
+      it 'does not return the authenticated resource owner' do
+        expect(parsed_body.id).to be_nil
+        expect(parsed_body.email).to be_nil
+        expect(parsed_body.created_at).to be_nil
+        expect(parsed_body.updated_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Within `lib/devise/api/controllers/helpers.rb` the `resource_class` is being passed into `Devise::Api::Responses::ErrorResponse` on initialization. `resource_class` is a method inherited from the devise controllers so unfortunately, if we use `authenticate_devise_api_token!` in any controller that doesn't inherit from one, the gem will throw for blank, expired and revoked tokens, rather than handling it cleanly and returning the proper error.

I've added what I think is a clean fix for the issue, and some accompanying specs. I'm happy to make any tweaks if needed :)

This issue was initially raised here https://github.com/nejdetkadir/devise-api/issues/24#issue-1765280427