### PR TITLE
Fix Refresh token AbstractController::DoubleRenderError

### DIFF
--- a/app/controllers/devise/api/tokens_controller.rb
+++ b/app/controllers/devise/api/tokens_controller.rb
@@ -122,7 +122,7 @@ module Devise
           error_response = Devise::Api::Responses::ErrorResponse.new(request, error: :revoked_token,
                                                                               resource_class: resource_class)
 
-          render json: error_response.body, status: error_response.status
+          return render json: error_response.body, status: error_response.status
         end
 
         Devise.api.config.before_refresh.call(current_devise_api_refresh_token, request)

--- a/spec/requests/tokens_spec.rb
+++ b/spec/requests/tokens_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       let(:devise_api_token) { build(:devise_api_token, resource_owner: user) }
 
       before do
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
       end
 
       it 'returns http unauthorized' do
@@ -533,7 +533,7 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       let(:devise_api_token) { create(:devise_api_token, :refresh_token_expired, resource_owner: user) }
 
       before do
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
       end
 
       it 'returns http unauthorized' do
@@ -541,8 +541,8 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       end
 
       it 'returns an error response' do
-        expect(parsed_body.error).to eq 'invalid_token'
-        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.invalid_token')])
+        expect(parsed_body.error).to eq 'expired_refresh_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.expired_refresh_token')])
       end
 
       it 'does not refresh the token' do
@@ -555,7 +555,7 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       let(:devise_api_token) { create(:devise_api_token, :revoked, resource_owner: user) }
 
       before do
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
       end
 
       it 'returns http unauthorized' do
@@ -563,8 +563,8 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       end
 
       it 'returns an error response' do
-        expect(parsed_body.error).to eq 'invalid_token'
-        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.invalid_token')])
+        expect(parsed_body.error).to eq 'revoked_token'
+        expect(parsed_body.error_description).to eq([I18n.t('devise.api.error_response.revoked_token')])
       end
 
       it 'does not refresh the token' do


### PR DESCRIPTION
In `app/controllers/api/devise/tokens_controller.rb#refresh` was causing `AbstractController::DoubleRenderError` when `access_token` is revoked due to a missing return.

```ruby
        if current_devise_api_refresh_token.revoked?
          error_response = Devise::Api::Responses::ErrorResponse.new(request, error: :revoked_token,
                                                                              resource_class: resource_class)

          return render json: error_response.body, status: error_response.status
        end
```

In `spec/requests/token_spec.rb` some `refresh_token` tests was passing `access_token` in headers

```ruby
      before do
        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
      end
```