### PR TITLE
Fix dbl render error on revoked token

### DIFF
--- a/app/controllers/devise/api/tokens_controller.rb
+++ b/app/controllers/devise/api/tokens_controller.rb
@@ -122,7 +122,7 @@ module Devise
           error_response = Devise::Api::Responses::ErrorResponse.new(request, error: :revoked_token,
                                                                               resource_class: resource_class)
 
-          render json: error_response.body, status: error_response.status
+          return render json: error_response.body, status: error_response.status
         end
 
         Devise.api.config.before_refresh.call(current_devise_api_refresh_token, request)


### PR DESCRIPTION
If the refresh token route was hit, and the token was already revoked, the code would render a JSON error, but it would not return. This meant that the gem would continue executing and eventually hit another render condition, causing a rails double render error.

Adding a return to this case fixes the issue.