### PR TITLE
Allow define extra fields for sign up

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Devise.setup do |config|
 
     # Sign up
     api.sign_up.enabled = true
+    api.sign_up.extra_fields = []
 
     # Authorization
     api.authorization.key = 'Authorization'

--- a/app/controllers/devise/api/tokens_controller.rb
+++ b/app/controllers/devise/api/tokens_controller.rb
@@ -149,7 +149,7 @@ module Devise
       private
 
       def sign_up_params
-        params.permit(*resource_class.authentication_keys,
+        params.permit(*Devise.api.config.sign_up.extra_fields, *resource_class.authentication_keys,
                       *::Devise::ParameterSanitizer::DEFAULT_PERMITTED_ATTRIBUTES[:sign_up]).to_h
       end
 

--- a/lib/devise/api/configuration.rb
+++ b/lib/devise/api/configuration.rb
@@ -22,6 +22,7 @@ module Devise
 
       setting :sign_up, reader: true do
         setting :enabled, default: true, reader: true
+        setting :extra_fields, default: [], reader: true
       end
 
       setting :authorization, reader: true do

--- a/spec/devise/api/configuration_spec.rb
+++ b/spec/devise/api/configuration_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe Devise::Api::Configuration do
       it 'enabled is true' do
         expect(config.sign_up.enabled).to eq true
       end
+
+      it 'extra_fields is an empty array' do
+        expect(config.sign_up.extra_fields).to eq []
+      end
     end
 
     context 'authorization' do


### PR DESCRIPTION
First of all, thank you very much for the work, I love this gem.

I would love to have the option to add a tos field to the sign up.

So this PR adds the `extra_fields` option in the `sign_up` config to be used by the method `sign_up_params` in the `TokensController`. I hope it is useful and can be included.