### PR TITLE
Add extra fields from config to resource owner

### DIFF
--- a/lib/devise/api/responses/token_response.rb
+++ b/lib/devise/api/responses/token_response.rb
@@ -41,13 +41,15 @@ module Devise
             refresh_token: Devise.api.config.refresh_token.enabled ? token.refresh_token : nil,
             expires_in: token.expires_in,
             token_type: ::Devise.api.config.authorization.scheme,
-            resource_owner: {
-              id: resource_owner.id,
-              email: resource_owner.email,
-              created_at: resource_owner.created_at,
-              updated_at: resource_owner.updated_at
-            }
+            resource_owner: default_resource_owner
           }.compact
+        end
+
+        def default_resource_owner
+          keys_to_extract = %i[id email created_at updated_at]
+          keys_to_extract |= Devise.api.config.extra_fields.map(&:to_sym) if Devise.api.config.extra_fields.present?
+
+          resource_owner.slice(*keys_to_extract)
         end
 
         def status

--- a/lib/devise/api/responses/token_response.rb
+++ b/lib/devise/api/responses/token_response.rb
@@ -47,7 +47,9 @@ module Devise
 
         def default_resource_owner
           keys_to_extract = %i[id email created_at updated_at]
-          keys_to_extract |= Devise.api.config.extra_fields.map(&:to_sym) if Devise.api.config.extra_fields.present?
+          if Devise.api.config.sign_up.extra_fields.present?
+            keys_to_extract |= Devise.api.config.sign_up.extra_fields.map(&:to_sym)
+          end
 
           resource_owner.slice(*keys_to_extract)
         end

--- a/spec/requests/tokens_spec.rb
+++ b/spec/requests/tokens_spec.rb
@@ -489,7 +489,8 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       let(:devise_api_token) { build(:devise_api_token, resource_owner: user) }
 
       before do
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token),
+                                       as: :json
       end
 
       it 'returns http unauthorized' do
@@ -533,7 +534,8 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       let(:devise_api_token) { create(:devise_api_token, :refresh_token_expired, resource_owner: user) }
 
       before do
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token),
+                                       as: :json
       end
 
       it 'returns http unauthorized' do
@@ -555,7 +557,8 @@ RSpec.describe Devise::Api::TokensController, type: :request do
       let(:devise_api_token) { create(:devise_api_token, :revoked, resource_owner: user) }
 
       before do
-        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token), as: :json
+        post refresh_user_tokens_path, headers: authentication_headers_for(user, devise_api_token, :refresh_token),
+                                       as: :json
       end
 
       it 'returns http unauthorized' do


### PR DESCRIPTION
Thanks for this wonderful gem

Based on PR #36 which adds extra sign_up fields to the `sign_up_params`, I thought it would be also useful to get back those added extra fields in the `resource_owner` property. 