### PR TITLE
Disable parameter wrapping in TokensController

### DIFF
--- a/app/controllers/devise/api/tokens_controller.rb
+++ b/app/controllers/devise/api/tokens_controller.rb
@@ -4,6 +4,7 @@
 module Devise
   module Api
     class TokensController < Devise.api.config.base_controller.constantize
+      wrap_parameters false
       skip_before_action :verify_authenticity_token, raise: false
       before_action :authenticate_devise_api_token!, only: %i[info]
 


### PR DESCRIPTION
As mentioned in https://github.com/nejdetkadir/devise-api/issues/8, the default rails behaviour for wrapping parameters was causing an unpermitted parameter message to appear in the server logs for requests made to the `TokensController`. This PR disables that behaviour so rails will no longer inject `token: {}` into the request params.

While I was in the repo I also fixed the 4 failing specs in `token_response_spec` and dried them up a little bit.