### PR TITLE
Fix nil memoization of tokens

### DIFF
--- a/app/controllers/devise/api/tokens_controller.rb
+++ b/app/controllers/devise/api/tokens_controller.rb
@@ -166,7 +166,7 @@ module Devise
       end
 
       def current_devise_api_refresh_token
-        return @current_devise_api_refresh_token if @current_devise_api_refresh_token
+        return @current_devise_api_refresh_token if defined?(@current_devise_api_refresh_token)
 
         token = find_devise_api_token
         devise_api_token_model = Devise.api.config.base_token_model.constantize

--- a/lib/devise/api/controllers/helpers.rb
+++ b/lib/devise/api/controllers/helpers.rb
@@ -38,7 +38,7 @@ module Devise
         end
 
         def current_devise_api_token
-          return @current_devise_api_token if @current_devise_api_token
+          return @current_devise_api_token if defined?(@current_devise_api_token)
 
           token = find_devise_api_token
           devise_api_token_model = Devise.api.config.base_token_model.constantize


### PR DESCRIPTION
### The problem
Memoization of tokens doesn't work if those turn out to be missing. This leads to constant token lookup when accessing it or token-dependent resources like `current_devise_api_token`.

### The solution
Instead of checking if the instance variable is truthy, check if it's defined.

---
Great gem, by the way! 💯 